### PR TITLE
Update param ordering test

### DIFF
--- a/src/test/kotlin/net/corda/training/state/IOUStateTests.kt
+++ b/src/test/kotlin/net/corda/training/state/IOUStateTests.kt
@@ -164,11 +164,16 @@ class IOUStateTests {
     @Test
     fun checkIOUStateParameterOrdering() {
         val fields = IOUState::class.java.declaredFields
-        assertEquals(fields[0], IOUState::class.java.getDeclaredField("amount"))
-        assertEquals(fields[1], IOUState::class.java.getDeclaredField("lender"))
-        assertEquals(fields[2], IOUState::class.java.getDeclaredField("borrower"))
-        assertEquals(fields[3], IOUState::class.java.getDeclaredField("paid"))
-        assertEquals(fields[4], IOUState::class.java.getDeclaredField("linearId"))
+        val amountIdx = fields.indexOf(IOUState::class.java.getDeclaredField("amount"))
+        val lenderIdx = fields.indexOf(IOUState::class.java.getDeclaredField("lender"))
+        val borrowerIdx = fields.indexOf(IOUState::class.java.getDeclaredField("borrower"))
+        val paidIdx = fields.indexOf(IOUState::class.java.getDeclaredField("paid"))
+        val linearIdIdx = fields.indexOf(IOUState::class.java.getDeclaredField("linearId"))
+
+        assert(amountIdx < lenderIdx)
+        assert(lenderIdx < borrowerIdx)
+        assert(borrowerIdx < paidIdx)
+        assert(paidIdx < linearIdIdx)
     }
 
     /**


### PR DESCRIPTION
Encountered an issue yesterday where if participants doesn't have a getter, it can become field[0], causing this test to fail despite a valid implementation.