### PR TITLE
Align Implementation with Template Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ State:
 
 Contract:
 
-* Template: `kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kotlin`
-* Issue Tests: `kotlin-source/src/test/kotlin/net/corda/training/contract/IOUIssueTests.kotlin`
-* Transfer Tests: `kotlin-source/src/test/kotlin/net/corda/training/contract/IOUTransferTests.kotlin`
-* Settle Tests: `kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kotlin`
+* Template: `kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kt`
+* Issue Tests: `kotlin-source/src/test/kotlin/net/corda/training/contract/IOUIssueTests.kt`
+* Transfer Tests: `kotlin-source/src/test/kotlin/net/corda/training/contract/IOUTransferTests.kt`
+* Settle Tests: `kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt`
 
 Flow:
 
-* Issue Solution: `kotlin-source/src/main/kotlin/net/corda/training/flow/IOUIssueFlow.kt`
-* Issue tests: `kotlin-source/src/test/kotlin/net/corda/training/flow/IOUIssueFlowTests.kt`
-* Transfer Solution: `kotlin-source/src/main/kotlin/net/corda/training/flow/IOUTransfer.kt`
-* Transfer tests: `kotlin-source/src/test/kotlin/net/corda/training/flow/IOUTransferFlowTests.kt`
-* Settle Solution: `kotlin-source/src/main/kotlin/net/corda/training/flow/IOUSettleFlow.kt`
-* Settle tests: `kotlin-source/src/test/kotlin/net/corda/training/flow/IOUSettleFlowTests.kt`
+* Issue Flow Solution: `kotlin-source/src/main/kotlin/net/corda/training/flow/IOUIssueFlow.kt`
+* Issue Flow tests: `kotlin-source/src/test/kotlin/net/corda/training/flow/IOUIssueFlowTests.kt`
+* Transfer Flow Solution: `kotlin-source/src/main/kotlin/net/corda/training/flow/IOUTransferFlow.kt`
+* Transfer Flow Tests: `kotlin-source/src/test/kotlin/net/corda/training/flow/IOUTransferFlowTests.kt`
+* Settle Flow Solution: `kotlin-source/src/main/kotlin/net/corda/training/flow/IOUSettleFlow.kt`
+* Settle Flow tests: `kotlin-source/src/test/kotlin/net/corda/training/flow/IOUSettleFlowTests.kt`
 
 The code in the following files was already added for you:
 

--- a/kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kt
+++ b/kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kt
@@ -43,7 +43,7 @@ class IOUContract : Contract {
             is Commands.Issue -> requireThat {
                 "No inputs should be consumed when issuing an IOU." using (tx.inputs.isEmpty())
                 "Only one output state should be created when issuing an IOU." using (tx.outputs.size == 1)
-                val iou = tx.outputStates.single() as IOUState
+                val iou = tx.outputsOfType<IOUState>().single()
                 "A newly issued IOU must have a positive amount." using (iou.amount.quantity > 0)
                 "The lender and borrower cannot have the same identity." using (iou.borrower != iou.lender)
                 "Both lender and borrower together only may sign IOU issue transaction." using
@@ -52,8 +52,8 @@ class IOUContract : Contract {
             is Commands.Transfer -> requireThat {
                 "An IOU transfer transaction should only consume one input state." using (tx.inputs.size == 1)
                 "An IOU transfer transaction should only create one output state." using (tx.outputs.size == 1)
-                val input = tx.inputStates.single() as IOUState
-                val output = tx.outputStates.single() as IOUState
+                val input = tx.inputsOfType<IOUState>().single()
+                val output = tx.outputsOfType<IOUState>().single()
                 "Only the lender property may change." using (input == output.withNewLender(input.lender))
                 "The lender property must change in a transfer." using (input.lender != output.lender)
                 "The borrower, old lender and new lender only must sign an IOU transfer transaction" using

--- a/kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kt
+++ b/kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kt
@@ -70,7 +70,7 @@ class IOUContract : Contract {
                 // Check that the cash is being assigned to us.
                 val inputIou = ious.inputs.single()
                 val acceptableCash = cash.filter { it.owner == inputIou.lender }
-                requireThat { "There must be output cash paid to the recipient." using (acceptableCash.isNotEmpty()) }
+                requireThat { "Output cash must be paid to the lender." using (acceptableCash.isNotEmpty()) }
                 // Sum the cash being sent to us (we don't care about the issuer).
                 val sumAcceptableCash = acceptableCash.sumCash().withoutIssuer()
                 val amountOutstanding = inputIou.amount - inputIou.paid
@@ -84,14 +84,10 @@ class IOUContract : Contract {
                     requireThat { "There must be one output IOU." using (ious.outputs.size == 1) }
                     // Check only the paid property changes.
                     val outputIou = ious.outputs.single()
-                    requireThat {
-                        "The amount may not change when settling." using (inputIou.amount == outputIou.amount)
-                        "The borrower may not change when settling." using (inputIou.borrower == outputIou.borrower)
-                        "The lender may not change when settling." using (inputIou.lender == outputIou.lender)
-                    }
+                    requireThat { "Only the paid amount can change." } using (inputIou.copy(paid = outputIou.paid) == outputIou)
                 }
                 requireThat {
-                    "Both lender and borrower together only must sign IOU settle transaction." using
+                    "Both lender and borrower together only must sign the IOU settle transaction." using
                             (command.signers.toSet() == inputIou.participants.map { it.owningKey }.toSet())
                 }
             }

--- a/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUIssueTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUIssueTests.kt
@@ -140,9 +140,10 @@ class IOUIssueTests {
      *   only one element in the previous task.
      * - We need to obtain a reference to the proposed IOU for issuance from the [LedgerTransaction.outputs] list.
      *   This list is typed as a list of [ContractState]s, therefore we need to cast the [ContractState] which we return
-     *   from [single] to an [IOUState]. You can use the Kotlin keyword 'as' to cast a class. E.g.
+     *   from [single] to an [IOUState]. [BaseTransaction.outputsOfType] is a helper function that finds states
+     *   of a specific type and casts the results to that type.
      *
-     *       val state = tx.outputStates.single() as XState
+     *       val state = tx.outputsOfType<X>().single()
      *
      * - When checking the [IOUState.amount] property is greater than zero, you need to check the
      *   [IOUState.amount.quantity] field.

--- a/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
@@ -25,14 +25,14 @@ import java.util.*
 /**
  * Practical exercise instructions for Contracts Part 3.
  * The objective here is to write some contract code that verifies a transaction to settle an [IOUState].
- * Settling is more complicated than transfering and issuing as it requires you to use multiple state types in a
+ * Settling is more complicated than transferring and issuing as it requires you to use multiple state types in a
  * transaction.
  * As with the [IOUIssueTests] and [IOUTransferTests] uncomment each unit test and run them one at a time. Use the body
  * of the tests and the task description to determine how to get the tests to pass.
  */
 class IOUSettleTests {
     private fun createCashState(amount: Amount<Currency>, owner: AbstractParty): Cash.State {
-        val defaultRef = ByteArray(1, { 1 })
+        val defaultRef = ByteArray(1) { 1 }
         return Cash.State(amount = amount `issued by`
                 TestIdentity(CordaX500Name(organisation = "MegaCorp", locality = "MegaPlanet", country = "US")).ref(defaultRef.first()),
                 owner = owner)
@@ -90,7 +90,8 @@ class IOUSettleTests {
      * IOUs.
      * TODO: Using [groupStates] add a constraint that checks for one group of input/output IOUs.
      * Hint:
-     * - The [single] function enforces a single element in a list or throws an exception.
+     * - The [single] function enforces a single element in a list or throws an exception. The test checks the
+     *   thrown exception so you do not have to define the exception message specifically in the code.
      * - The [groupStates] function takes two type parameters: the type of the state you wish to group by and the type
      *   of the grouping key used, in this case as you need to use the [linearId] and it is a [UniqueIdentifier].
      * - The [groupStates] also takes a lambda function which selects a property of the state to decide the groups.
@@ -202,13 +203,13 @@ class IOUSettleTests {
     /**
      * Task 5.
      * Not only do we need to check that [Cash] output states are present but we need to check that the payer is
-     * correctly assigning us as the new owner of these states.
+     * correctly assigning the lender as the new owner of these states.
      * TODO: Add a constraint to check that we are the new owner of the output cash.
      * Hint:
-     * - Not all of the cash may be assigned to us as some of the input cash may be sent back to the payer as change.
-     * - We need to use the [Cash.State.owner] property to check to see that it is the value of our public key.
-     * - Use [filter] to filter over the list of cash states to get the ones which are being assigned to us.
-     * - Once we have this filtered list, we can sum the cash being paid to us so we know how much is being settled.
+     * - Not all of the input cash may be assigned to the lender. Some of it may be sent back to the payer as change.
+     * - We need to use the [Cash.State.owner] property to check to see that it is the value of the lender public key.
+     * - Use [filter] to filter over the list of cash states to get the ones which are being assigned to the lender.
+     * - Once we have this filtered list, we can sum the cash being paid so we know how much is being settled.
      */
     @Test
     fun mustBeCashOutputStatesWithRecipientAsOwner() {
@@ -240,16 +241,16 @@ class IOUSettleTests {
 
     /**
      * Task 6.
-     * Now we need to sum the cash which is being assigned to us and compare this total against how much of the iou is
-     * left to pay.
+     * Now we need to sum the cash that is being assigned to the lender and compare this total against how much of the
+     * IOU is left to pay.
      * TODO: Add a constraint that checks we cannot be paid more than the remaining IOU amount left to pay.
      * Hint:
      * - The remaining amount of the IOU is the amount less the paid property.
      * - To sum a list of [Cash.State]s use the [sumCash] function.
      * - The [sumCash] function returns an [Issued<Amount<Currency>>] type. We don't care about the issuer so we can
      *   apply [withoutIssuer] to unwrap the [Amount] from [Issuer].
-     * - We can compare the amount left paid to the amount being paid to use, ensuring the amount being paid isn't too
-     *   much.
+     * - We can compare the amount left to be paid on the input IOU to the amount of cash being used,
+     *   ensuring the amount being paid isn't too much.
      */
     @Test
     fun cashSettlementAmountMustBeLessThanRemainingIOUAmount() {

--- a/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
@@ -201,7 +201,7 @@ class IOUSettleTests {
 
     /**
      * Task 5.
-     * Not only to we need to check that [Cash] output states are present but we need to check that the payer is
+     * Not only do we need to check that [Cash] output states are present but we need to check that the payer is
      * correctly assigning us as the new owner of these states.
      * TODO: Add a constraint to check that we are the new owner of the output cash.
      * Hint:
@@ -224,7 +224,7 @@ class IOUSettleTests {
                 output(Cash.PROGRAM_ID, "outputs cash", invalidCashPayment.ownableState)
                 command(BOB.publicKey, invalidCashPayment.command)
                 command(listOf(ALICE.publicKey, BOB.publicKey), IOUContract.Commands.Settle())
-                this `fails with` "There must be output cash paid to the recipient."
+                this `fails with` "Output cash must be paid to the lender."
             }
             transaction {
                 input(IOUContract.IOU_CONTRACT_ID, iou)
@@ -385,25 +385,7 @@ class IOUSettleTests {
                 output(IOUContract.IOU_CONTRACT_ID, iou.copy(borrower = ALICE.party, paid = 5.DOLLARS))
                 command(BOB.publicKey, fiveDollars.withNewOwner(newOwner = BOB.party).command)
                 command(listOf(ALICE.publicKey, BOB.publicKey), IOUContract.Commands.Settle())
-                this `fails with` "The borrower may not change when settling."
-            }
-            transaction {
-                input(IOUContract.IOU_CONTRACT_ID, iou)
-                input(Cash.PROGRAM_ID, fiveDollars)
-                output(Cash.PROGRAM_ID, fiveDollars.withNewOwner(newOwner = ALICE.party).ownableState)
-                output(IOUContract.IOU_CONTRACT_ID, iou.copy(amount = 0.DOLLARS, paid = 5.DOLLARS))
-                command(BOB.publicKey, fiveDollars.withNewOwner(newOwner = BOB.party).command)
-                command(listOf(ALICE.publicKey, BOB.publicKey), IOUContract.Commands.Settle())
-                this `fails with` "The amount may not change when settling."
-            }
-            transaction {
-                input(IOUContract.IOU_CONTRACT_ID, iou)
-                input(Cash.PROGRAM_ID, fiveDollars)
-                output(Cash.PROGRAM_ID, fiveDollars.withNewOwner(newOwner = ALICE.party).ownableState)
-                output(IOUContract.IOU_CONTRACT_ID, iou.copy(lender = CHARLIE.party, paid = 5.DOLLARS))
-                command(BOB.publicKey, fiveDollars.withNewOwner(newOwner = BOB.party).command)
-                command(listOf(ALICE.publicKey, BOB.publicKey), IOUContract.Commands.Settle())
-                this `fails with` "The lender may not change when settling."
+                this `fails with` "Only the paid amount can change."
             }
             transaction {
                 input(IOUContract.IOU_CONTRACT_ID, iou)
@@ -435,7 +417,7 @@ class IOUSettleTests {
                 command(BOB.publicKey, cashPayment.command)
                 output(IOUContract.IOU_CONTRACT_ID, iou.pay(5.DOLLARS))
                 command(listOf(ALICE.publicKey, CHARLIE.publicKey), IOUContract.Commands.Settle())
-                failsWith("Both lender and borrower together only must sign IOU settle transaction.")
+                failsWith("Both lender and borrower together only must sign the IOU settle transaction.")
             }
             transaction {
                 input(Cash.PROGRAM_ID, cash)
@@ -444,7 +426,7 @@ class IOUSettleTests {
                 command(BOB.publicKey, cashPayment.command)
                 output(IOUContract.IOU_CONTRACT_ID, iou.pay(5.DOLLARS))
                 command(BOB.publicKey, IOUContract.Commands.Settle())
-                failsWith("Both lender and borrower together only must sign IOU settle transaction.")
+                failsWith("Both lender and borrower together only must sign the IOU settle transaction.")
             }
             transaction {
                 input(Cash.PROGRAM_ID, cash)

--- a/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUTransferTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUTransferTests.kt
@@ -6,8 +6,10 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.contracts.requireSingleCommand
 import net.corda.core.identity.AbstractParty
+import net.corda.core.internal.packageName
 import net.corda.finance.DOLLARS
 import net.corda.finance.POUNDS
+import net.corda.finance.schemas.CashSchemaV1
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.ledger
 import net.corda.training.ALICE
@@ -30,7 +32,7 @@ class IOUTransferTests {
     }
     // A dummy command.
     class DummyCommand : CommandData
-    var ledgerServices = MockServices(listOf("net.corda.training"))
+    var ledgerServices = MockServices(listOf("net.corda.training", "net.corda.finance.contracts.asset", CashSchemaV1::class.packageName))
 
     /**
      * Task 1.

--- a/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUIssueFlowTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUIssueFlowTests.kt
@@ -30,8 +30,10 @@ class IOUIssueFlowTests {
 
     @Before
     fun setup() {
-        mockNetwork = MockNetwork(listOf("net.corda.training"),
-                notarySpecs = listOf(MockNetworkNotarySpec(CordaX500Name("Notary","London","GB"))))
+        mockNetwork = MockNetwork(
+            listOf("net.corda.training"),
+            notarySpecs = listOf(MockNetworkNotarySpec(CordaX500Name("Notary", "London", "GB")))
+        )
         a = mockNetwork.createNode(MockNodeParameters())
         b = mockNetwork.createNode(MockNodeParameters())
         val startedNodes = arrayListOf(a, b)
@@ -54,7 +56,7 @@ class IOUIssueFlowTests {
      * - Create a [TransactionBuilder] and pass it a notary reference.
      * -- A notary [Party] object can be obtained from [FlowLogic.serviceHub.networkMapCache].
      * -- In this training project there is only one notary
-     * - Create an [IOUContract.Commands.Issue] inside a new [Command] object.
+     * - Create an [IOUContract.Commands.Issue] inside a new [Command].
      * -- The required signers will be the same as the state's participants
      * -- Add the [Command] to the transaction builder [addCommand].
      * - Use the flow's [IOUState] parameter as the output state with [addOutputState]
@@ -81,8 +83,10 @@ class IOUIssueFlowTests {
         val command = ptx.tx.commands.single()
         assert(command.value is IOUContract.Commands.Issue)
         assert(command.signers.toSet() == iou.participants.map { it.owningKey }.toSet())
-        ptx.verifySignaturesExcept(borrower.owningKey,
-                mockNetwork.defaultNotaryNode.info.legalIdentitiesAndCerts.first().owningKey)
+        ptx.verifySignaturesExcept(
+            borrower.owningKey,
+            mockNetwork.defaultNotaryNode.info.legalIdentitiesAndCerts.first().owningKey
+        )
     }
 
     /**
@@ -120,7 +124,7 @@ class IOUIssueFlowTests {
      * TODO: Amend the [IOUIssueFlow] to collect the [otherParty]'s signature.
      * Hint:
      * On the Initiator side:
-     * - Get a set of the required signers from the participants who are not the node
+     * - Get a set of signers required from the participants who are not the node
      * - - [ourIdentity] will give you the identity of the node you are operating as
      * - Use [initiateFlow] to get a set of [FlowSession] objects
      * - - Using [state.participants] as a base to determine the sessions needed is recommended. [participants] is on

--- a/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUSettleFlowTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUSettleFlowTests.kt
@@ -78,9 +78,10 @@ class IOUSettleFlowTests {
      * TODO: Grab the IOU for the given [linearId] from the vault, build and sign the settle transaction.
      * Hints:
      * - Use the code from the [IOUTransferFlow] to get the correct [IOUState] from the vault.
-     * - You will need to use the [Cash.generateSpend] functionality of the vault to add the cash states and cash command
-     *   to your transaction. The API is quite simple. It takes a reference to a [TransactionBuilder], an [Amount] and
-     *   the [Party] object for the recipient. The function will mutate your builder by adding the states and commands.
+     * - You will need to use the [CashUtils.generateSpend] functionality of the vault to add the cash states and cash command
+     *   to your transaction. The API is quite simple. It takes a reference to a [ServiceHub], the [TransactionBuilder],
+     *   an [Amount], [PartyAndCertificate] representing out identity (sender) and the [Party] object for the recipient.
+     *   The function will mutate your builder by adding the states and commands.
      * - You then need to produce the output [IOUState] by using the [IOUState.pay] function.
      * - Add the input [IOUState] [StateAndRef] and the new output [IOUState] to the transaction.
      * - Sign the transaction and return it.

--- a/kotlin-source/src/test/kotlin/net/corda/training/state/IOUStateTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/state/IOUStateTests.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 
 /**
  * Practical exercise instructions.
@@ -136,6 +137,9 @@ class IOUStateTests {
         IOUState::class.java.getDeclaredField("linearId")
         // Is the linearId field of the correct type?
         assertEquals(IOUState::class.java.getDeclaredField("linearId").type, UniqueIdentifier::class.java)
+        // Check field is set to a not null value
+        val iouState = IOUState(1.POUNDS, ALICE.party, BOB.party)
+        assertNotNull(iouState.linearId)
     }
 
     /**
@@ -175,7 +179,7 @@ class IOUStateTests {
         val iou = IOUState(10.DOLLARS, ALICE.party, BOB.party)
         assertEquals(5.DOLLARS, iou.pay(5.DOLLARS).paid)
         assertEquals(3.DOLLARS, iou.pay(1.DOLLARS).pay(2.DOLLARS).paid)
-        assertEquals(10.DOLLARS, iou.pay(5.DOLLARS).pay(3.DOLLARS).pay(2.DOLLARS).paid)
+        assertEquals(10.5.DOLLARS, iou.pay(5.DOLLARS).pay(3.DOLLARS).pay(2.5.DOLLARS).paid)
     }
 
     /**
@@ -186,6 +190,6 @@ class IOUStateTests {
     fun checkWithNewLenderHelperMethod() {
         val iou = IOUState(10.DOLLARS, ALICE.party, BOB.party)
         assertEquals(MINICORP.party, iou.withNewLender(MINICORP.party).lender)
-        assertEquals(MEGACORP.party, iou.withNewLender(MEGACORP.party).lender)
+        assertEquals(MEGACORP.party, iou.withNewLender(MINICORP.party).withNewLender(MEGACORP.party).lender)
     }
 }


### PR DESCRIPTION
Aligning tests and breaking changes in template to the sample solution.

PR for the template changes - https://github.com/corda/corda-training-template/pull/44

This includes some minor changes to syntax and instantiation of setup functions. I took the template as the source of truth for these and fixed syntax changes there too.